### PR TITLE
Setup build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,10 @@
   "name": "Python 3",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
   "image": "mcr.microsoft.com/devcontainers/python:0-3.11",
-  // Features to add to the dev container. More info: https://containers.dev/features.
-  // "features": {},
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+	},
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
   // Use 'postCreateCommand' to run commands after the container is created.

--- a/.github/workflows/create_github_release.yml
+++ b/.github/workflows/create_github_release.yml
@@ -1,0 +1,69 @@
+name: Create Release
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    permissions: write-all
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install toml build
+
+      - name: Get package version
+        id: get_version
+        run: |
+          echo "::set-output name=version::$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")"
+
+      - name: Check if release exists
+        id: check_release
+        run: |
+          response=$(curl -s -o /dev/null -w "%{http_code}" -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.get_version.outputs.version }}")
+          if [[ $response -eq 200 ]]; then
+            echo "Release with the same tag already exists. Please increment the version in the pyproject.toml file"
+            exit 1
+          fi
+
+      - name: Build and package
+        run: |
+          python -m build
+
+      - name: Install and test built package
+        run: |
+          python -m pip install ./dist/*.whl
+          python -c "import cc_sdk; from importlib.metadata import version; version('cc_sdk')"
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.get_version.outputs.version }}
+          release_name: Release v${{ steps.get_version.outputs.version }}
+          body: |
+            Release for version ${{ steps.get_version.outputs.version }}
+          draft: false
+          prerelease: false
+
+      - name: Upload distributions
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/dist/cc_sdk-${{ steps.get_version.outputs.version }}-py3-none-any.whl
+          asset_name: cc_sdk-${{ steps.get_version.outputs.version }}-py3-none-any.whl
+          asset_content_type: application/octet-stream

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Will Lehman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,97 @@
 # cc-python-sdk
-The Python SDK for developing plugins for Cloud Compute
+
+[![PyPI version](https://badge.fury.io/py/cc_sdk.svg)](https://badge.fury.io/py/cc_sdk)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+cc_sdk is the Python Software Development Kit used to develop plugins for Cloud Compute.
+
+## Installation
+
+You can install cc_sdk in two ways: from source or through the pip package manager.
+
+### Installing from source
+
+To install cc_sdk from source, follow these steps:
+
+1. Clone the repository:
+
+```shell
+git clone https://github.com/USACE/cc-python-sdk.git
+```
+
+2. Navigate to the project directory:
+
+```shell
+cd cc-python-sdk
+```
+
+3. Create a virtual environment (optional but recommended):
+
+```shell
+python3 -m venv venv
+source venv/bin/activate
+```
+
+4. Install the package dependencies:
+
+```shell
+pip install -r requirements.txt
+```
+
+5. Install the build dependencies
+
+```shell
+python3 -m pip install --upgrade build
+```
+
+6. Build cc_sdk from the `pyproject.toml`:
+
+```shell
+python3 -m build
+```
+
+7. Install the generated wheel (replace <version> with the version of the wheel file built):
+
+```shell
+pip install dist/cc_sdk-<version>-py3-none-any.whl
+```
+
+or 
+
+```shell
+pip install dist/*.whl
+```
+
+Now you have successfully installed cc_sdk from source.
+
+## Install from pre-built distribution
+
+Download the release from the 'Releases' page of this repository, then install with pip:
+
+```shell
+pip install <path/to/wheel/*.whl>
+```
+
+### Installing through pip
+
+To install cc_sdk using pip, simply run the following command:
+
+```shell
+pip install cc_sdk
+```
+
+This will download the latest version of cc_sdk from the Python Package Index (PyPI) and install it into your Python environment.
+
+## Usage
+
+Once cc_sdk is installed, you can start using its functionality in your Python projects. Here's a simple example:
+
+```python
+import cc_sdk
+
+# Use the functions and classes provided by cc_sdk
+```
+
+## Documentation
+
+TODO. See example plugin [here](https://<>)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ name = "cc_sdk"
 version = "0.0.1"
 authors = [
   { name="Will Lehman", email="William.P.Lehman@usace.army.mil" },
+  { name="Brendan Barnes", email="brendan.barnes@mbakerintl.com" },
+  { name="Thomas Williams", email="thomas.williams@wsp.com" },
 ]
 description = "The Python SDK for developing plugins for Cloud Compute"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "cc_sdk"
+version = "0.0.1"
+authors = [
+  { name="Will Lehman", email="William.P.Lehman@usace.army.mil" },
+]
+description = "The Python SDK for developing plugins for Cloud Compute"
+readme = "README.md"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/USACE/cc-python-sdk"
+"Bug Tracker" = "https://github.com/USACE/cc-python-sdk/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dependencies = [
+  'attrs >= 22.2.0',
+  'boto3 >= 1.26.93',
+]
 
 [project.urls]
 "Homepage" = "https://github.com/USACE/cc-python-sdk"


### PR DESCRIPTION
1. Added pyproject.toml (modern standard as opposed to setup.py)
2. Added LICENSE file for MIT license (same as Java CC SDK)
3. Updated readme with build and install instructions
4. Added new github workflow file to build, test, and publish binary distributions (.whl) to GitHub Releases on this repo. This will run each time a push to main occurs (with branch protection on this implies all tests from the "lint and test" workflow have passed during the PR review). We can make this manual if desired.
Note that the release is set to fail if the version number in the .toml file is not incremented (i.e. the release already exists).


@thwllms, Will you be implementing the PyPI deployment? Otherwise I can work on that if you provide the credentials. I'm thinking we can create a new workflow for the main branch with the `workflow_run` condition making the GitHub release a dependency of the PyPI release?